### PR TITLE
Remove `template_name`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -341,7 +341,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
 
   tier                = "WebServer"
   solution_stack_name = "${var.solution_stack_name}"
-  template_name       = "${var.settings}"
+//  template_name       = "${var.settings}"
 
   tags {
     Name      = "${module.label.id}"

--- a/main.tf
+++ b/main.tf
@@ -341,7 +341,6 @@ resource "aws_elastic_beanstalk_environment" "default" {
 
   tier                = "WebServer"
   solution_stack_name = "${var.solution_stack_name}"
-//  template_name       = "${var.settings}"
 
   tags {
     Name      = "${module.label.id}"

--- a/variables.tf
+++ b/variables.tf
@@ -26,10 +26,6 @@ variable "zone_id" {
   default = ""
 }
 
-variable "settings" {
-  default = ""
-}
-
 variable "config_source" {
   default = ""
 }


### PR DESCRIPTION
## What

* Remove `template_name`


## Why

* Even if it's empty, it conflicts with `solution_stack_name`
* Terraform does not like `template_name` and `solution_stack_name` to be provided at the same time
