### PR TITLE
Add Support for Environment Variables Passed by Map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 *.tfstate.backup
 
 # Module directory
-.terraform/
-
+.terraform
 .idea
 *.iml

--- a/main.tf
+++ b/main.tf
@@ -614,11 +614,11 @@ resource "aws_elastic_beanstalk_environment" "default" {
   }
 
   ###=========================== ENV vars ========================== ###
-  setting {
-    namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${element(keys(var.env), 0)}"
-    value     = "${element(values(var.env), 0)}"
-  }
+//  setting {
+//    namespace = "aws:elasticbeanstalk:application:environment"
+//    name      = "${element(keys(var.env), 0)}"
+//    value     = "${element(values(var.env), 0)}"
+//  }
   depends_on = ["aws_security_group.default"]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -9,10 +9,10 @@ module "label" {
   tags       = "${var.tags}"
 }
 
-module "vector_map" {
-  source = "git::https://github.com/cloudposse/tf_vector_map.git?ref=init"
-  env    = "${var.env}"
-}
+//module "vector_map" {
+//  source = "git::https://github.com/cloudposse/tf_vector_map.git?ref=init"
+//  env    = "${var.env}"
+//}
 
 data "aws_region" "default" {
   current = true
@@ -614,31 +614,11 @@ resource "aws_elastic_beanstalk_environment" "default" {
   }
 
   ###=========================== ENV vars ========================== ###
-
   setting {
+    count     = "${length(keys(var.env))}"
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${module.vector_map.vector.0.key}"
-    value     = "${module.vector_map.vector.0.value}"
-  }
-  setting {
-    namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${module.vector_map.vector.1.key}"
-    value     = "${module.vector_map.vector.1.value}"
-  }
-  setting {
-    namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${module.vector_map.vector.2.key}"
-    value     = "${module.vector_map.vector.2.value}"
-  }
-  setting {
-    namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${module.vector_map.vector.3.key}"
-    value     = "${module.vector_map.vector.3.value}"
-  }
-  setting {
-    namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${module.vector_map.vector.4.key}"
-    value     = "${module.vector_map.vector.4.value}"
+    name      = "${element(keys(var.env), count.index)}"
+    value     = "${element(values(var.env), count.index)}"
   }
   depends_on = ["aws_security_group.default"]
 }

--- a/main.tf
+++ b/main.tf
@@ -336,6 +336,16 @@ resource "aws_security_group" "default" {
   }
 }
 
+resource "null_resource" "env_vars" {
+  # Max number of supported ENV variables
+  count = 20
+
+  triggers {
+    key   = "${count.index >= length(keys(var.env_map)) ? format(var.env_default_key, count.index+1) : element(keys(var.env_map), count.index)}"
+    value = "${count.index >= length(values(var.env_map)) ? var.env_default_value : element(values(var.env_map), count.index)}"
+  }
+}
+
 #
 # Full list of options:
 # http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options-general.html#command-options-general-elasticbeanstalkmanagedactionsplatformupdate
@@ -608,58 +618,107 @@ resource "aws_elastic_beanstalk_environment" "default" {
     value     = "true"
   }
 
-  ###================================== ENV vars =================================###
+  ###===================== Application ENV vars ======================###
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${length(keys(var.env)) > 0 ? element(keys(var.env), 0) : "ENV_0"}"
-    value     = "${length(keys(var.env)) > 0 ? element(values(var.env), 0) : "UNSET"}"
+    name      = "${null_resource.env_vars.0.triggers.key}"
+    value     = "${null_resource.env_vars.0.triggers.value}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${length(keys(var.env)) > 1 ? element(keys(var.env), 1) : "ENV_1"}"
-    value     = "${length(keys(var.env)) > 1 ? element(values(var.env), 1) : "UNSET"}"
+    name      = "${null_resource.env_vars.1.triggers.key}"
+    value     = "${null_resource.env_vars.1.triggers.value}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${length(keys(var.env)) > 2 ? element(keys(var.env), 2) : "ENV_2"}"
-    value     = "${length(keys(var.env)) > 2 ? element(values(var.env), 2) : "UNSET"}"
+    name      = "${null_resource.env_vars.2.triggers.key}"
+    value     = "${null_resource.env_vars.2.triggers.value}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${length(keys(var.env)) > 3 ? element(keys(var.env), 3) : "ENV_3"}"
-    value     = "${length(keys(var.env)) > 3 ? element(values(var.env), 3) : "UNSET"}"
+    name      = "${null_resource.env_vars.3.triggers.key}"
+    value     = "${null_resource.env_vars.3.triggers.value}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${length(keys(var.env)) > 4 ? element(keys(var.env), 4) : "ENV_4"}"
-    value     = "${length(keys(var.env)) > 4 ? element(values(var.env), 4) : "UNSET"}"
+    name      = "${null_resource.env_vars.4.triggers.key}"
+    value     = "${null_resource.env_vars.4.triggers.value}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${length(keys(var.env)) > 5 ? element(keys(var.env), 5) : "ENV_5"}"
-    value     = "${length(keys(var.env)) > 5 ? element(values(var.env), 5) : "UNSET"}"
+    name      = "${null_resource.env_vars.5.triggers.key}"
+    value     = "${null_resource.env_vars.5.triggers.value}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${length(keys(var.env)) > 6 ? element(keys(var.env), 6) : "ENV_6"}"
-    value     = "${length(keys(var.env)) > 6 ? element(values(var.env), 6) : "UNSET"}"
+    name      = "${null_resource.env_vars.6.triggers.key}"
+    value     = "${null_resource.env_vars.6.triggers.value}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${length(keys(var.env)) > 7 ? element(keys(var.env), 7) : "ENV_7"}"
-    value     = "${length(keys(var.env)) > 7 ? element(values(var.env), 7) : "UNSET"}"
+    name      = "${null_resource.env_vars.7.triggers.key}"
+    value     = "${null_resource.env_vars.7.triggers.value}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${length(keys(var.env)) > 8 ? element(keys(var.env), 8) : "ENV_8"}"
-    value     = "${length(keys(var.env)) > 8 ? element(values(var.env), 8) : "UNSET"}"
+    name      = "${null_resource.env_vars.8.triggers.key}"
+    value     = "${null_resource.env_vars.8.triggers.value}"
   }
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${length(keys(var.env)) > 9 ? element(keys(var.env), 9) : "ENV_9"}"
-    value     = "${length(keys(var.env)) > 9 ? element(values(var.env), 9) : "UNSET"}"
+    name      = "${null_resource.env_vars.9.triggers.key}"
+    value     = "${null_resource.env_vars.9.triggers.value}"
   }
-
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.10.triggers.key}"
+    value     = "${null_resource.env_vars.10.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.11.triggers.key}"
+    value     = "${null_resource.env_vars.11.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.12.triggers.key}"
+    value     = "${null_resource.env_vars.12.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.13.triggers.key}"
+    value     = "${null_resource.env_vars.13.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.14.triggers.key}"
+    value     = "${null_resource.env_vars.14.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.15.triggers.key}"
+    value     = "${null_resource.env_vars.15.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.16.triggers.key}"
+    value     = "${null_resource.env_vars.16.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.17.triggers.key}"
+    value     = "${null_resource.env_vars.17.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.18.triggers.key}"
+    value     = "${null_resource.env_vars.18.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.19.triggers.key}"
+    value     = "${null_resource.env_vars.19.triggers.value}"
+  }
   depends_on = ["aws_security_group.default"]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -615,10 +615,9 @@ resource "aws_elastic_beanstalk_environment" "default" {
 
   ###=========================== ENV vars ========================== ###
   setting {
-    count     = "${length(keys(var.env))}"
     namespace = "aws:elasticbeanstalk:application:environment"
-    name      = "${element(keys(var.env), count.index)}"
-    value     = "${element(values(var.env), count.index)}"
+    name      = "${element(keys(var.env), 0)}"
+    value     = "${element(values(var.env), 0)}"
   }
   depends_on = ["aws_security_group.default"]
 }

--- a/main.tf
+++ b/main.tf
@@ -9,11 +9,6 @@ module "label" {
   tags       = "${var.tags}"
 }
 
-//module "vector_map" {
-//  source = "git::https://github.com/cloudposse/tf_vector_map.git?ref=init"
-//  env    = "${var.env}"
-//}
-
 data "aws_region" "default" {
   current = true
 }
@@ -613,12 +608,58 @@ resource "aws_elastic_beanstalk_environment" "default" {
     value     = "true"
   }
 
-  ###=========================== ENV vars ========================== ###
-//  setting {
-//    namespace = "aws:elasticbeanstalk:application:environment"
-//    name      = "${element(keys(var.env), 0)}"
-//    value     = "${element(values(var.env), 0)}"
-//  }
+  ###================================== ENV vars =================================###
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${length(keys(var.env)) > 0 ? element(keys(var.env), 0) : "ENV_0"}"
+    value     = "${length(keys(var.env)) > 0 ? element(values(var.env), 0) : "UNSET"}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${length(keys(var.env)) > 1 ? element(keys(var.env), 1) : "ENV_1"}"
+    value     = "${length(keys(var.env)) > 1 ? element(values(var.env), 1) : "UNSET"}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${length(keys(var.env)) > 2 ? element(keys(var.env), 2) : "ENV_2"}"
+    value     = "${length(keys(var.env)) > 2 ? element(values(var.env), 2) : "UNSET"}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${length(keys(var.env)) > 3 ? element(keys(var.env), 3) : "ENV_3"}"
+    value     = "${length(keys(var.env)) > 3 ? element(values(var.env), 3) : "UNSET"}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${length(keys(var.env)) > 4 ? element(keys(var.env), 4) : "ENV_4"}"
+    value     = "${length(keys(var.env)) > 4 ? element(values(var.env), 4) : "UNSET"}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${length(keys(var.env)) > 5 ? element(keys(var.env), 5) : "ENV_5"}"
+    value     = "${length(keys(var.env)) > 5 ? element(values(var.env), 5) : "UNSET"}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${length(keys(var.env)) > 6 ? element(keys(var.env), 6) : "ENV_6"}"
+    value     = "${length(keys(var.env)) > 6 ? element(values(var.env), 6) : "UNSET"}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${length(keys(var.env)) > 7 ? element(keys(var.env), 7) : "ENV_7"}"
+    value     = "${length(keys(var.env)) > 7 ? element(values(var.env), 7) : "UNSET"}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${length(keys(var.env)) > 8 ? element(keys(var.env), 8) : "ENV_8"}"
+    value     = "${length(keys(var.env)) > 8 ? element(values(var.env), 8) : "UNSET"}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${length(keys(var.env)) > 9 ? element(keys(var.env), 9) : "ENV_9"}"
+    value     = "${length(keys(var.env)) > 9 ? element(values(var.env), 9) : "UNSET"}"
+  }
+
   depends_on = ["aws_security_group.default"]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,11 @@ module "label" {
   tags       = "${var.tags}"
 }
 
+module "vector_map" {
+  source = "git::https://github.com/cloudposse/tf_vector_map.git?ref=init"
+  env    = "${var.env}"
+}
+
 data "aws_region" "default" {
   current = true
 }
@@ -18,7 +23,7 @@ data "aws_region" "default" {
 #
 data "aws_iam_policy_document" "service" {
   statement {
-    sid     = ""
+    sid = ""
 
     actions = [
       "sts:AssumeRole",
@@ -29,7 +34,7 @@ data "aws_iam_policy_document" "service" {
       identifiers = ["elasticbeanstalk.amazonaws.com"]
     }
 
-    effect  = "Allow"
+    effect = "Allow"
   }
 }
 
@@ -53,7 +58,7 @@ resource "aws_iam_role_policy_attachment" "service" {
 #
 data "aws_iam_policy_document" "ec2" {
   statement {
-    sid     = ""
+    sid = ""
 
     actions = [
       "sts:AssumeRole",
@@ -64,11 +69,11 @@ data "aws_iam_policy_document" "ec2" {
       identifiers = ["ec2.amazonaws.com"]
     }
 
-    effect  = "Allow"
+    effect = "Allow"
   }
 
   statement {
-    sid     = ""
+    sid = ""
 
     actions = [
       "sts:AssumeRole",
@@ -79,7 +84,7 @@ data "aws_iam_policy_document" "ec2" {
       identifiers = ["ssm.amazonaws.com"]
     }
 
-    effect  = "Allow"
+    effect = "Allow"
   }
 }
 
@@ -134,9 +139,9 @@ resource "aws_ssm_activation" "ec2" {
 
 data "aws_iam_policy_document" "default" {
   statement {
-    sid       = ""
+    sid = ""
 
-    actions   = [
+    actions = [
       "elasticloadbalancing:DescribeInstanceHealth",
       "elasticloadbalancing:DescribeLoadBalancers",
       "elasticloadbalancing:DescribeTargetHealth",
@@ -156,13 +161,13 @@ data "aws_iam_policy_document" "default" {
 
     resources = ["*"]
 
-    effect    = "Allow"
+    effect = "Allow"
   }
 
   statement {
-    sid       = "AllowOperations"
+    sid = "AllowOperations"
 
-    actions   = [
+    actions = [
       "autoscaling:AttachInstances",
       "autoscaling:CreateAutoScalingGroup",
       "autoscaling:CreateLaunchConfiguration",
@@ -250,13 +255,13 @@ data "aws_iam_policy_document" "default" {
 
     resources = ["*"]
 
-    effect    = "Allow"
+    effect = "Allow"
   }
 
   statement {
-    sid       = "AllowS3OperationsOnElasticBeanstalkBuckets"
+    sid = "AllowS3OperationsOnElasticBeanstalkBuckets"
 
-    actions   = [
+    actions = [
       "s3:*",
     ]
 
@@ -264,13 +269,13 @@ data "aws_iam_policy_document" "default" {
       "arn:aws:s3:::*",
     ]
 
-    effect    = "Allow"
+    effect = "Allow"
   }
 
   statement {
-    sid       = "AllowDeleteCloudwatchLogGroups"
+    sid = "AllowDeleteCloudwatchLogGroups"
 
-    actions   = [
+    actions = [
       "logs:DeleteLogGroup",
     ]
 
@@ -278,13 +283,13 @@ data "aws_iam_policy_document" "default" {
       "arn:aws:logs:*:*:log-group:/aws/elasticbeanstalk*",
     ]
 
-    effect    = "Allow"
+    effect = "Allow"
   }
 
   statement {
-    sid       = "AllowCloudformationOperationsOnElasticBeanstalkStacks"
+    sid = "AllowCloudformationOperationsOnElasticBeanstalkStacks"
 
-    actions   = [
+    actions = [
       "cloudformation:*",
     ]
 
@@ -293,7 +298,7 @@ data "aws_iam_policy_document" "default" {
       "arn:aws:cloudformation:*:*:stack/eb-*",
     ]
 
-    effect    = "Allow"
+    effect = "Allow"
   }
 }
 
@@ -306,7 +311,7 @@ resource "aws_security_group" "default" {
   name        = "${module.label.id}"
   description = "Allow all inbound traffic"
 
-  vpc_id      = "${var.vpc_id}"
+  vpc_id = "${var.vpc_id}"
 
   ingress {
     from_port   = 0
@@ -314,18 +319,21 @@ resource "aws_security_group" "default" {
     protocol    = -1
     cidr_blocks = ["0.0.0.0/0"]
   }
+
   ingress {
     from_port       = 0
     to_port         = 0
     protocol        = -1
     security_groups = ["${var.security_groups}"]
   }
+
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
+
   tags {
     Name      = "${module.label.id}"
     Namespace = "${var.namespace}"
@@ -339,8 +347,8 @@ resource "aws_security_group" "default" {
 #
 
 resource "aws_elastic_beanstalk_environment" "default" {
-  name                = "${module.label.id}"
-  application         = "${var.app}"
+  name        = "${module.label.id}"
+  application = "${var.app}"
 
   tier                = "WebServer"
   solution_stack_name = "${var.solution_stack_name}"
@@ -406,25 +414,21 @@ resource "aws_elastic_beanstalk_environment" "default" {
     name      = "MeasureName"
     value     = "CPUUtilization"
   }
-
   setting {
     namespace = "aws:autoscaling:trigger"
     name      = "Statistic"
     value     = "Average"
   }
-
   setting {
     namespace = "aws:autoscaling:trigger"
     name      = "Unit"
     value     = "Percent"
   }
-
   setting {
     namespace = "aws:autoscaling:trigger"
     name      = "LowerThreshold"
     value     = "${var.autoscale_lower_bound}"
   }
-
   setting {
     namespace = "aws:autoscaling:trigger"
     name      = "UpperThreshold"
@@ -438,221 +442,214 @@ resource "aws_elastic_beanstalk_environment" "default" {
     name      = "SecurityGroups"
     value     = "${aws_security_group.default.id}"
   }
-
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "InstanceType"
     value     = "${var.instance_type}"
   }
-
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "IamInstanceProfile"
     value     = "${aws_iam_instance_profile.ec2.name}"
   }
-
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
     name      = "EC2KeyName"
     value     = "${var.keypair}"
   }
-
   setting {
     namespace = "aws:autoscaling:asg"
     name      = "Availability Zones"
     value     = "Any 2"
   }
-
   setting {
     namespace = "aws:autoscaling:asg"
     name      = "MinSize"
     value     = "${var.autoscale_min}"
   }
-
   setting {
     namespace = "aws:autoscaling:asg"
     name      = "MaxSize"
     value     = "${var.autoscale_max}"
   }
-
   setting {
     namespace = "aws:elb:loadbalancer"
     name      = "CrossZone"
     value     = "true"
   }
-
   setting {
     namespace = "aws:elb:listener"
     name      = "ListenerProtocol"
     value     = "HTTP"
   }
-
   setting {
     namespace = "aws:elb:listener"
     name      = "InstancePort"
     value     = "80"
   }
-
   setting {
     namespace = "aws:elb:listener"
     name      = "ListenerEnabled"
     value     = "${var.loadbalancer_certificate_arn == "" ? "true" : "false"}"
   }
-
   setting {
     namespace = "aws:elb:listener:443"
     name      = "ListenerProtocol"
     value     = "HTTPS"
   }
-
   setting {
     namespace = "aws:elb:listener:443"
     name      = "InstancePort"
     value     = "80"
   }
-
   setting {
     namespace = "aws:elb:listener:443"
     name      = "SSLCertificateId"
     value     = "${var.loadbalancer_certificate_arn}"
   }
-
   setting {
     namespace = "aws:elb:listener:443"
     name      = "ListenerEnabled"
     value     = "${var.loadbalancer_certificate_arn == "" ? "false" : "true"}"
   }
-
   setting {
     namespace = "aws:elb:policies"
     name      = "ConnectionDrainingEnabled"
     value     = "true"
   }
-
   setting {
     namespace = "aws:elbv2:loadbalancer"
     name      = "AccessLogsS3Bucket"
     value     = "${aws_s3_bucket.elb_logs.id}"
   }
-
   setting {
     namespace = "aws:elbv2:loadbalancer"
     name      = "AccessLogsS3Enabled"
     value     = "true"
   }
-
   setting {
     namespace = "aws:elbv2:listener:default"
     name      = "ListenerEnabled"
     value     = "${var.loadbalancer_certificate_arn == "" ? "true" : "false"}"
   }
-
   setting {
     namespace = "aws:elbv2:listener:443"
     name      = "ListenerEnabled"
     value     = "${var.loadbalancer_certificate_arn == "" ? "false" : "true"}"
   }
-
   setting {
     namespace = "aws:elbv2:listener:443"
     name      = "Protocol"
     value     = "HTTPS"
   }
-
   setting {
     namespace = "aws:elbv2:listener:443"
     name      = "SSLCertificateArns"
     value     = "${var.loadbalancer_certificate_arn}"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:environment"
     name      = "LoadBalancerType"
     value     = "${var.loadbalancer_type}"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:environment"
     name      = "ServiceRole"
     value     = "${aws_iam_role.service.name}"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:application"
     name      = "Application Healthcheck URL"
     value     = "HTTP:80${var.healthcheck_url}"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:healthreporting:system"
     name      = "SystemType"
     value     = "enhanced"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:command"
     name      = "BatchSizeType"
     value     = "Fixed"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:command"
     name      = "BatchSize"
     value     = "1"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:command"
     name      = "DeploymentPolicy"
     value     = "Rolling"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "BASE_HOST"
     value     = "${var.name}"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "CONFIG_SOURCE"
     value     = "${var.config_source}"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:managedactions"
     name      = "ManagedActionsEnabled"
     value     = "true"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:managedactions"
     name      = "PreferredStartTime"
     value     = "Sun:10:00"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:managedactions:platformupdate"
     name      = "UpdateLevel"
     value     = "minor"
   }
-
   setting {
     namespace = "aws:elasticbeanstalk:managedactions:platformupdate"
     name      = "InstanceRefreshEnabled"
     value     = "true"
   }
 
-  depends_on          = ["aws_security_group.default"]
+  ###=========================== ENV vars ========================== ###
+
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${module.vector_map.vector.0.key}"
+    value     = "${module.vector_map.vector.0.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${module.vector_map.vector.1.key}"
+    value     = "${module.vector_map.vector.1.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${module.vector_map.vector.2.key}"
+    value     = "${module.vector_map.vector.2.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${module.vector_map.vector.3.key}"
+    value     = "${module.vector_map.vector.3.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${module.vector_map.vector.4.key}"
+    value     = "${module.vector_map.vector.4.value}"
+  }
+  depends_on = ["aws_security_group.default"]
 }
 
 data "aws_elb_service_account" "main" {}
 
 data "aws_iam_policy_document" "elb_logs" {
   statement {
-    sid       = ""
+    sid = ""
 
-    actions   = [
+    actions = [
       "s3:PutObject",
     ]
 
@@ -665,7 +662,7 @@ data "aws_iam_policy_document" "elb_logs" {
       identifiers = ["${data.aws_elb_service_account.main.arn}"]
     }
 
-    effect    = "Allow"
+    effect = "Allow"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -342,8 +342,8 @@ resource "null_resource" "env_vars" {
   count = 50
 
   triggers {
-    key   = "${count.index >= length(keys(var.env_map)) ? format(var.env_default_key, count.index+1) : element(keys(var.env_map), count.index)}"
-    value = "${count.index >= length(values(var.env_map)) ? var.env_default_value : element(values(var.env_map), count.index)}"
+    key   = "${count.index >= length(keys(var.env_vars)) ? format(var.env_default_key, count.index+1) : element(keys(var.env_vars), count.index)}"
+    value = "${count.index >= length(values(var.env_vars)) ? var.env_default_value : element(values(var.env_vars), count.index)}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -336,9 +336,10 @@ resource "aws_security_group" "default" {
   }
 }
 
+# This pattern of generating ENV vars will be changed in the future once Terraform implements iterrators: https://github.com/hashicorp/terraform/issues/7034
 resource "null_resource" "env_vars" {
   # Max number of supported ENV variables
-  count = 20
+  count = 50
 
   triggers {
     key   = "${count.index >= length(keys(var.env_map)) ? format(var.env_default_key, count.index+1) : element(keys(var.env_map), count.index)}"
@@ -617,7 +618,6 @@ resource "aws_elastic_beanstalk_environment" "default" {
     name      = "InstanceRefreshEnabled"
     value     = "true"
   }
-
   ###===================== Application ENV vars ======================###
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
@@ -718,6 +718,156 @@ resource "aws_elastic_beanstalk_environment" "default" {
     namespace = "aws:elasticbeanstalk:application:environment"
     name      = "${null_resource.env_vars.19.triggers.key}"
     value     = "${null_resource.env_vars.19.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.20.triggers.key}"
+    value     = "${null_resource.env_vars.20.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.21.triggers.key}"
+    value     = "${null_resource.env_vars.21.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.22.triggers.key}"
+    value     = "${null_resource.env_vars.22.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.23.triggers.key}"
+    value     = "${null_resource.env_vars.23.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.24.triggers.key}"
+    value     = "${null_resource.env_vars.24.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.25.triggers.key}"
+    value     = "${null_resource.env_vars.25.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.26.triggers.key}"
+    value     = "${null_resource.env_vars.26.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.27.triggers.key}"
+    value     = "${null_resource.env_vars.27.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.28.triggers.key}"
+    value     = "${null_resource.env_vars.28.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.29.triggers.key}"
+    value     = "${null_resource.env_vars.29.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.30.triggers.key}"
+    value     = "${null_resource.env_vars.30.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.31.triggers.key}"
+    value     = "${null_resource.env_vars.31.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.32.triggers.key}"
+    value     = "${null_resource.env_vars.32.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.33.triggers.key}"
+    value     = "${null_resource.env_vars.33.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.34.triggers.key}"
+    value     = "${null_resource.env_vars.34.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.35.triggers.key}"
+    value     = "${null_resource.env_vars.35.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.36.triggers.key}"
+    value     = "${null_resource.env_vars.36.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.37.triggers.key}"
+    value     = "${null_resource.env_vars.37.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.38.triggers.key}"
+    value     = "${null_resource.env_vars.38.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.39.triggers.key}"
+    value     = "${null_resource.env_vars.39.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.40.triggers.key}"
+    value     = "${null_resource.env_vars.40.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.41.triggers.key}"
+    value     = "${null_resource.env_vars.41.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.42.triggers.key}"
+    value     = "${null_resource.env_vars.42.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.43.triggers.key}"
+    value     = "${null_resource.env_vars.43.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.44.triggers.key}"
+    value     = "${null_resource.env_vars.44.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.45.triggers.key}"
+    value     = "${null_resource.env_vars.45.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.46.triggers.key}"
+    value     = "${null_resource.env_vars.46.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.47.triggers.key}"
+    value     = "${null_resource.env_vars.47.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.48.triggers.key}"
+    value     = "${null_resource.env_vars.48.triggers.value}"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "${null_resource.env_vars.49.triggers.key}"
+    value     = "${null_resource.env_vars.49.triggers.value}"
   }
   depends_on = ["aws_security_group.default"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -115,3 +115,8 @@ variable "tags" {
   type    = "map"
   default = {}
 }
+
+variable "env" {
+  default = {}
+  type    = "map"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -124,7 +124,7 @@ variable "env_default_value" {
   default = "UNSET"
 }
 
-variable "env_map" {
+variable "env_vars" {
   default = {}
   type    = "map"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -116,7 +116,15 @@ variable "tags" {
   default = {}
 }
 
-variable "env" {
+variable "env_default_key" {
+  default = "DEFAULT_ENV_%d"
+}
+
+variable "env_default_value" {
+  default = "UNSET"
+}
+
+variable "env_map" {
   default = {}
   type    = "map"
 }


### PR DESCRIPTION
## What

* Add custom (application specific) `ENV` variables to the `EB` container


## Why

* For many applications (_e.g._ `Jenkings` or `WordPress`) we need to provide custom `ENV` variables into the `EB` container, _e.g._ `EFS` host, `Jenkins` initial user and password, or database user and password

## TODO
* `README.md`
* Describe two ways of providing application `ENV` variables to the `EB` container:
   * Using variable `config_source`
   * Using variable `env_map`

